### PR TITLE
Fix dark looking Mii lighting by not setting XYZ light parameters by default

### DIFF
--- a/mii.js
+++ b/mii.js
@@ -18,9 +18,17 @@ const STUDIO_RENDER_DEFAULTS = {
 	characterXRotate: 0,
 	characterYRotate: 0,
 	characterZRotate: 0,
+	/*
+	The defaults of zero produce a dark-looking Mii render.
+	I'm not sure if we know the default, or if it's even a static value.
+	The API doesn't even accept invalid, negative, or blank values for these.
+	These values will be clamped if you specify them manually,
+	... but for now they will be excluded.
 	lightXDirection: 0,
 	lightYDirection: 0,
 	lightZDirection: 0,
+	*/
+	// Seemingly doesn't change the image when the directions are zero or none.
 	lightDirectionMode: 'none',
 	instanceCount: 1,
 	instanceRotationMode: 'model',
@@ -637,9 +645,9 @@ class Mii {
 		queryParams.characterXRotate = clamp(queryParams.characterXRotate, 359);
 		queryParams.characterYRotate = clamp(queryParams.characterYRotate, 359);
 		queryParams.characterZRotate = clamp(queryParams.characterZRotate, 359);
-		queryParams.lightXDirection = clamp(queryParams.lightXDirection, 359);
-		queryParams.lightYDirection = clamp(queryParams.lightYDirection, 359);
-		queryParams.lightZDirection = clamp(queryParams.lightZDirection, 359);
+		queryParams.lightXDirection !== undefined && (queryParams.lightXDirection = clamp(queryParams.lightXDirection, 359));
+		queryParams.lightYDirection !== undefined && (queryParams.lightYDirection = clamp(queryParams.lightYDirection, 359));
+		queryParams.lightZDirection !== undefined && (queryParams.lightZDirection = clamp(queryParams.lightZDirection, 359));
 		queryParams.lightDirectionMode = STUDIO_RENDER_LIGHT_DIRECTION_MODS.includes(queryParams.lightDirectionMode) ? queryParams.lightDirectionMode : STUDIO_RENDER_DEFAULTS.lightDirectionMode;
 		queryParams.instanceCount = clamp(queryParams.instanceCount, 1, 16);
 		queryParams.instanceRotationMode = STUDIO_RENDER_INSTANCE_ROTATION_MODES.includes(queryParams.instanceRotationMode) ? queryParams.instanceRotationMode : STUDIO_RENDER_DEFAULTS.instanceRotationMode;


### PR DESCRIPTION
For those who aren't familiar, Mii studio renders look dark on Pretendo, or anything else using mii-js. Something like this:
![Light directions set to 0](https://studio.mii.nintendo.com/miis/image.png?type=face&expression=normal&width=96&bgColor=FFFFFF00&clothesColor=default&cameraXRotate=0&cameraYRotate=0&cameraZRotate=0&characterXRotate=0&characterYRotate=0&characterZRotate=0&lightXDirection=0&lightYDirection=0&lightZDirection=0&lightDirectionMode=none&instanceCount=1&instanceRotationMode=model&data=f1fe053941505a644c55626b6a7477818e899098989f9fa5bcc2c8cad2d9a9bcc4cbcedcdfd3d9cecad5dcd3dae1ec)

This is due to light directions being set to 0 by default. Pretty much all of the default query parameters set by mii-js are correct, but this is the exception. I'm actually not sure if the default is even a static value. [The defaults linked in the README.md](https://github.com/PretendoNetwork/mii-js?tab=readme-ov-file#lightxdirection) look more correct, but it's still not exactly the same.

Here is the way Miis are supposed to look if you just exclude the light direction parameters (not the lightDirectionMode though, removing or setting it seemingly doesn't do anything):
![Light directions unset](https://studio.mii.nintendo.com/miis/image.png?type=face&expression=normal&width=96&bgColor=FFFFFF00&clothesColor=default&cameraXRotate=0&cameraYRotate=0&cameraZRotate=0&characterXRotate=0&characterYRotate=0&characterZRotate=0&lightDirectionMode=none&instanceCount=1&instanceRotationMode=model&data=f1fe053941505a644c55626b6a7477818e899098989f9fa5bcc2c8cad2d9a9bcc4cbcedcdfd3d9cecad5dcd3dae1ec)

This approach to fixing the issue just removes the default light directions, and clamps them in studioUrl() if they are defined.
It may have been a cleaner solution to set them to negative or blank values, but the API doesn't accept those, they need to be excluded entirely.

Feel free to make this better or let me know if there are cons to this approach, thanks.