### PR TITLE
Remove light direction params when mode is none

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Default: `0`
 ### lightYDirection
 Rotate the light source position/direction in the Y axis
 
-Default: `359`
+Default: `0`
 
 | Min | Max |
 | --- | --- |
@@ -476,7 +476,7 @@ Default: `359`
 ### lightZDirection
 Rotate the light source position/direction in the Z axis
 
-Default: `359`
+Default: `0`
 
 | Min | Max |
 | --- | --- |
@@ -484,6 +484,8 @@ Default: `359`
 
 ### lightDirectionMode
 Changes the light direction mode
+
+**When this is set to the default of none, the light direction parameters are not sent at all.**
 
 Default: `none`
 

--- a/mii.js
+++ b/mii.js
@@ -644,9 +644,16 @@ class Mii {
 		queryParams.instanceCount = clamp(queryParams.instanceCount, 1, 16);
 		queryParams.instanceRotationMode = STUDIO_RENDER_INSTANCE_ROTATION_MODES.includes(queryParams.instanceRotationMode) ? queryParams.instanceRotationMode : STUDIO_RENDER_DEFAULTS.instanceRotationMode;
 
-		const query = new URLSearchParams(queryParams).toString();
+		const query = new URLSearchParams(queryParams);
 
-		return `${STUDIO_RENDER_URL_BASE}?${query}`;
+		if (queryParams.lightDirectionMode === 'none') {
+			query.delete('lightDirectionMode');
+			query.delete('lightXDirection');
+			query.delete('lightYDirection');
+			query.delete('lightZDirection');
+		}
+
+		return `${STUDIO_RENDER_URL_BASE}?${query.toString()}`;
 	}
 
 	studioAssetUrlBody() {


### PR DESCRIPTION
Here's my new PR to replace #2, though of course feel free to do it your own way if you don't like it.

I also went ahead and clarified in the README about how the parameters are actually zero by default, and added a little note saying the directions will be excluded if the mode is indeed set to none.
It may not be a bad idea to show a warning or something when the light directions are not the defaults, but the mode is still none, but, this gets the important part out of the way.
(I couldn't find any code in the org that sets these anyway)